### PR TITLE
Avoid trailing spaces at the end of a line when writing JSON

### DIFF
--- a/src/Json.fs
+++ b/src/Json.fs
@@ -154,7 +154,7 @@ module Json =
                         match xs with
                         | [] -> ()
                         | x :: [] -> writeJson x
-                        | x :: xs -> writeJson x; write ", "; (if expandArray then newline()); f xs
+                        | x :: xs -> writeJson x; write ","; (if expandArray then newline() else write " "); f xs
                     if expandArray then
                         write "["
                         indent <- indent + 1
@@ -169,7 +169,7 @@ module Json =
                         match xs with
                         | [] -> ()
                         | (k, x) :: [] -> write "\""; writeString k; write "\": "; writeJson x
-                        | (k, x) :: xs -> write "\""; writeString k; write "\": "; writeJson x; write ", "; (if expandObj then newline()); f xs
+                        | (k, x) :: xs -> write "\""; writeString k; write "\": "; writeJson x; write ","; (if expandObj then newline() else write " "); f xs
                     if expandObj then
                         write "{"
                         indent <- indent + 1

--- a/tests/Json/Settings.fs
+++ b/tests/Json/Settings.fs
@@ -41,11 +41,11 @@ type ``3: Settings tests``() =
                 let no_expand = Json({ Json.Settings.Default with FormatExpandArrays = false }).WithDefaults()
 
                 Assert.AreEqual("[2, 4, 8]", no_expand.ToString [2; 4; 8])
-                Assert.AreEqual("[\n    2, \n    4, \n    8\n]", expand.ToString [2; 4; 8])
+                Assert.AreEqual("[\n    2,\n    4,\n    8\n]", expand.ToString [2; 4; 8])
 
     [<Test>] member this.FormatExpandObjects() =
                 let expand = Json({ Json.Settings.Default with FormatExpandObjects = true }).WithDefaults()
                 let no_expand = Json({ Json.Settings.Default with FormatExpandObjects = false }).WithDefaults()
     
                 Assert.AreEqual("""{"X": 2, "Y": 4}""", no_expand.ToString { Record.X = 2L; Y = 4.0f })
-                Assert.AreEqual("{\n    \"X\": 2, \n    \"Y\": 4\n}", expand.ToString { Record.X = 2L; Y = 4.0f })
+                Assert.AreEqual("{\n    \"X\": 2,\n    \"Y\": 4\n}", expand.ToString { Record.X = 2L; Y = 4.0f })


### PR DESCRIPTION
Looks visually the same but is nicer on size and removes annoying spaces that can get in the way of manual editing

Truly approaching the most minor of changes possible at this point